### PR TITLE
Fixed to use the version instead of "*". the project does not work when ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "express": "3.0.5",
-    "jade": "*"
+    "jade": "0.30.0"
   }
 }


### PR DESCRIPTION
I got some errors when running the npm start after npm install. it seems there is a most updated version of jade template and your code does not work at all.. this configuration fixed the error.
